### PR TITLE
Use node16 instead of node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   include-hidden-files:
     description: "Includes files and folders starting with '.' in file pattern matching"
     required: true
-    default: false
+    default: "false"
   input-file:
     description: "Path to file containing checklist definitions"
     required: true
@@ -23,7 +23,7 @@ inputs:
   show-paths:
     description: "Shows the matched file paths in the Github comment"
     required: true
-    default: true
+    default: "true"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: true
     default: "true"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "check-square"


### PR DESCRIPTION
As per the warning emitted whenever this action runs, GitHub advises to migrate to Node16 (as described in https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

I also changed the values of the `default` properties to `string`, as per the [schema validation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault).