### PR TITLE
allow merging of checklist comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Overrides the default header text in the PR comment.
 
 Overrides the default footer text in the PR comment.
 
+##### `merge-comment`
+
+Merges any new checklist items with the existing checklist comment.
+
 ##### `include-hidden-files`
 
 Includes files and folders starting with `.` when matching. Defaults to `false`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -19207,11 +19207,11 @@ function getChecklistPaths() {
     return parsedFile.paths;
 }
 function formatItemsForPath(previousComment, mergeComment, [path, items]) {
-    const existingChecklistItems = previousComment.split("\n").filter(line => line !== "" && (line.startsWith('- [ ]') || line.startsWith('- [x]'))).map(line => line.substring(5).trim());
     
     let checklistItems = items;
     if (!!previousComment && mergeComment) {
         checklistItems = checklistItems.map(item => {
+            const existingChecklistItems = previousComment.split("\n").filter(line => line !== "" && (line.startsWith('- [ ]') || line.startsWith('- [x]'))).map(line => line.substring(5).trim());
             const existingItem = existingChecklistItems.find(existingItem => existingItem.includes(item));
             if (!existingItem){
                 return item;


### PR DESCRIPTION
This PR adds an optional flag to allow for the comment made by the action to be merged with an existing checklist comment.

The motivation is to update the checklists with net-new items, but preserve the state of previous items to reduce friction in PR flows. This is especially helpful when the developer is forced to check all items before proceeding to merge.