### PR TITLE
Run action on Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: true
     default: "true"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "check-square"


### PR DESCRIPTION
As described in the warning emitted by GitHub, Node 16 has reached its EOL and should be replaced by Node 20 (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).